### PR TITLE
Remake da EvalCad e suporte a UTF-8

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -11,7 +11,6 @@ import pwinput as pw # Transforma senha em asterisco / pip install pwinput
 from packages.login_module import login_check
 from packages.eval_module import eval
 from packages.signup_module import add_cad
-from packages.evalcad_module import evalcad
 
 while True: # Loop do login até ser valido
     id = []
@@ -32,7 +31,6 @@ while True: # Loop de opções
     
     if opção == 1:
         add_cad() # Funcao cadastro
-        evalcad()
     elif opção == 2:
         eval() # Funcao avaliacao
     elif opção == 3:

--- a/packages/eval_module.py
+++ b/packages/eval_module.py
@@ -4,7 +4,7 @@ def eval():
     target_dir = 'Data_Sample/' # Diretório relativo
     csv_path = os.path.join(target_dir, filename) # Seleciona diretório
 
-    with open(csv_path, 'r+', newline='') as aval_csv:
+    with open(csv_path, 'r+', newline='',encoding='utf-8') as aval_csv:
         reader_obj = csv.reader(aval_csv, delimiter=',') # Cria um objeto de leitura para CSV
         next(reader_obj, None) # Ignora headers
 

--- a/packages/evalcad_module.py
+++ b/packages/evalcad_module.py
@@ -1,20 +1,32 @@
 def evalcad():
-    import os, sys, csv # Puxa imports da main
-    import pandas as pd # Importa o pandas 
-    filename = 'login_data.csv' # Nome do arquivo
-    target_dir = 'data_sample/' # Diretório relativo
-    csv_path = os.path.join(target_dir, filename) # Seleciona diretório
-    csv_path2 = os.path.join(target_dir,'aval_data.csv') # Concatena o diretório e nome do aval_data.csv
+    from Main import csv, sys, os
 
-# Lê os arquivos .csv em forma de dataframe
-    df_original = pd.read_csv(csv_path) 
-    df_destino = pd.read_csv(csv_path2)
+    filename = 'login_data.csv'
+    target_dir = 'data_sample/'
+    csv_path = os.path.join(target_dir, filename)
+    csv_path2 = os.path.join(target_dir, 'aval_data.csv')
 
-# Seleciona apenas a coluna id e nome do login_data.csv e cria um novo dataframe somente com os dados filtrados
-    colunas_desejadas = ['id', 'nome'] 
-    df_selecionado = df_original[colunas_desejadas].tail(1)
+    with open(csv_path, 'r', encoding='utf-8') as f1, open(csv_path2,'r+', encoding='utf-8') as f2:
+        # Lê os arquivos .csv usando a biblioteca csv
+        reader1 = csv.DictReader(f1)
+        reader2 = csv.DictReader(f2)
 
-    df_concatenado = pd.concat([df_selecionado,df_destino],ignore_index=True) #Aqui o novo dataframe filtrado é concatenado junto com a aval_data.csv
+        # Cria um dicionário com os dados do último registro do arquivo login_data.csv
+        last_row = None
+        for row in reader1:
+            last_row = row
+        dict_selecionado = {'id': last_row['id'], 'nome': last_row['nome']}
 
-    df_concatenado.to_csv(csv_path2, index=False) #Nesse momento, todo o arquivo aval_data.csv é substituido por um novo aval_data.csv com os novos dados dentro.
-evalcad()
+        # Verifica se o usuário a ser adicionado já existe no arquivo destino
+        exists = False
+        for row in reader2:
+            if row['id'] == dict_selecionado['id']:
+                exists = True
+                break
+        # Adiciona uma nova linha no arquivo destino se o usuário não existir
+        if not exists:
+            f2.write('\n')
+            writer = csv.DictWriter(f2, fieldnames=['id', 'nome'],skipinitialspace=False,lineterminator='') #Isso é o que realmente escreve no arquivo. O parâmetro 'lineterminator' é forçado com o valor nulo para não criar uma linha nova.
+            writer.writerow(dict_selecionado)
+            
+            f2.write(',,,,,,,,,,,,,,,,,,,,,,,,,')

--- a/packages/login_module.py
+++ b/packages/login_module.py
@@ -4,7 +4,7 @@ def login_check(id, nome):
     target_dir = 'Data_Sample/' # Diretório relativo
     csv_path = os.path.join(target_dir, filename) # Seleciona diretório
 
-    with open(csv_path,'r', newline='') as cad_csv: # Abrir o arquivo para extrair logins
+    with open(csv_path,'r', newline='',encoding='utf-8') as cad_csv: # Abrir o arquivo para extrair logins
         reader_obj = csv.reader(cad_csv, quoting=csv.QUOTE_NONE) # Cria um objeto de leitura para CSV
         print('\nBem vindo ao eVAL360!\n'
                 'Antes de acessar, por favor faça seu login\n')

--- a/packages/signup_module.py
+++ b/packages/signup_module.py
@@ -1,5 +1,6 @@
 def add_cad():
     from Main import os, sys, csv, pw, uuid # Puxa imports da main
+    from packages.evalcad_module import evalcad
     filename = 'login_data.csv' # Nome do arquivo
     target_dir = 'Data_Sample/' # Diretório relativo
     csv_path = os.path.join(target_dir, filename) # Seleciona diretório
@@ -24,6 +25,7 @@ def add_cad():
     # Inserção das variáveis dentro de uma lista
 
     # Sem um novo arquivo "cadastro.csv" seria criado dentro do CWD (no caso, direto no repo DevMinds).
-    with open(csv_path,'a', newline='') as cad_csv: # Abre csv, inserindo uma nova linha
+    with open(csv_path,'a', newline='',encoding='utf-8') as cad_csv: # Abre csv, inserindo uma nova linha
         csv_writer = csv.writer(cad_csv) # Objeto de escrito do csv
         csv_writer.writerow([id, nome, email, senha])
+    evalcad()


### PR DESCRIPTION
Refiz todo o módulo evalcad e adicionei suporte ao encoding UTF-8 a todo o aplicativo. O que significa que um usuário teste chamado de JééfinhUU_ZonaNorte possa utilizar o app sem quebrar. (Sim, eu testei o JééfinhUU_ZonaNorte e funciona kk)
O sincronismo entre a login_data.csv e a aval_data.csv agora só acontece após o cadastro de um novo usuário, o que significa que a evalcad não tem mais nada a ver com a main.